### PR TITLE
Add details to hackathon main page

### DIFF
--- a/hackathon/README.md
+++ b/hackathon/README.md
@@ -13,6 +13,7 @@ sharing of ideas and discussion in the lead up to
 the hackathon, during and after.
 
 * **Date**: Friday 29 September, 2023
+* **Check-in and registration**: 09:30 -- 10:00 (WEST)
 * **Time**: 10:00 -- 15:00 (WEST)
 * **Location**: [SANA Metropolitan
   Hotel](https://www.sanahotels.com/en/hotel/sana-metropolitan/)

--- a/hackathon/README.md
+++ b/hackathon/README.md
@@ -7,23 +7,106 @@ MDAnalysis core developers on code --- it can be your own project
 where you want some help or start building something amazing with a
 few like-minded hackers!
 
-* date: **Friday 29 September, 2023**
-* time: 9:30 -- 15:00 (WEST)
-* location: [SANA Metropolitan
+**Discord server**: The [#hackathon][hackathon-channel] channel on the 
+[MDAnalysis Discord server][discord] is available for any questions, 
+sharing of ideas and discussion in the lead up to 
+the hackathon, during and after.
+
+* **Date**: Friday 29 September, 2023
+* **Time**: 10:00 -- 15:00 (WEST)
+* **Location**: [SANA Metropolitan
   Hotel](https://www.sanahotels.com/en/hotel/sana-metropolitan/)
   Madrid Room. 
   
   Address: R. Soeiro Pereira Gomes 2, 1600-198 Lisbon, PT
-* contact: @fiona-naughton (Fiona Naughton)
+* **Contact**: @fiona-naughton (Fiona Naughton)
   
 ## Schedule 
 
-| time (WEST)   | what's happening?  |  location   |
-|---------------|--------------------|-------------|
-| 9:00 - 9:30   | registration       |             |
-| 9:30 - 11:30  | hackathon          | Madrid room |
-| 12:00 - 13:00 | lunch              |             |
-| 13:00 - 15:00 | hackathon          | Madrid room |
+| time (WEST)   | what's happening?                |  location   |
+|---------------|----------------------------------|-------------|
+| 9:30 - 10:00  | Registration                     |             |
+| 10:00 - 10:30 | Introduction and team gathering  | Madrid room |
+| 10:30 - 12:00 | Hackathon                        | Madrid room |
+| 12:00 - 13:00 | Lunch                            |             |
+| 13:00 - 14:30 | Hackathon                        | Madrid room |
+| 14:30 - 15:00 | Wrap-up and [showcase](#showcase)| Madrid room |
+
+## How do I participate?
+### Before the hackathon
+ - Read the hackathon materials, and read/watch any of the linked
+   resources you're not already familiar with.
+   
+ - If you don't already have a GitHub account, make one now! This
+   will allow you to work collaboratively with others, and you'll need
+   one to contribute to the main MDAnalysis codebase.
+ - Join the [discord][] to follow the discussion on the
+   [#hackathon channel][hackathon-channel]!
+ - Look through the [ideas below](#What-should-I-work-on?), and start
+   to think how you'd like use your time during the hackathon to
+   contribute to MDAnalysis.
+   - If you have a specific project of your own in mind: raise an issue
+     on the [UGM Issue Tracker][issue-tracker] so that you have a
+     dedicated place share and discuss your idea and gather other
+     attendees to help you. Also share your idea (with a link to the
+     issue) on the [#hackathon channel][hackathon-channel].
+   - If you see an existing idea (from the MDAnalysis team or another
+     attendee) that interests you, find the associated issue and join
+     the discussion there. Even if you don't intend to work on an
+     issue yourself (or are yet undecided), any questions, comments
+     and thoughts are always useful.
+
+### At the hackathon
+ - **Pick an idea and gather a team!** Use the associated issues (see
+   below) to find others who expressed interest in a particular project.
+   You can also team up with others to tackle multiple smaller issues
+   together.
+   
+   While you can choose to work individually, we strongly encourage you
+   to make use of this opportunity to work alongside like-minded
+   attendees this will both make the experience more fun, and improve
+   your code's quality.
+   - *Working on a project as a team:* Discuss how you could split your
+     project into different tasks. Make a central repository for your
+     code on GitHub, and use issues to keep track of and assign
+     developers to these tasks. Use Pull Requests (and push
+     frequently!) to share your progress with your team and allow them
+     to review or comment - and in turn, review and comment on your
+     teammates' progress. Eventually, these PRs can be merged to
+     combine everyone's work into a greater whole.
+     
+ - Update progress on the associated UGM issue (if one doesn't exist
+   yet, make one now) to let other attendees and the MDAnalysis team
+   know how you're going!
+ - Continue to use the [#hackathon][hackathon-channel] discord channel
+   for any broader discussion, and remember the MDAnalysis team is
+   on hand to help you out!
+ - Hack away, make new friends, build something awesome - and have fun!
+
+#### Showcase
+At the end of the session, we will be holding a brief showcase to allow
+those who wish to share the work they achieved over the hackathon. 
+
+This could be advertising a new feature you created or showing off a 
+bug fix you're particularly proud of; and need not be a "finished" 
+product - you can talk about what you got done, what future plans 
+are, and if there's still help wanted.
+
+If you do wish to share, add a slide for you/your team to the 
+shared presentation (*link TBA*) - a template will be provided. 
+Depending how many wish to present, time may be short, so have 
+an elevator pitch summary for your work ready!
+
+### After the hackathon
+It's very possible that you won't "finish" a project within the 
+timelimit of the hackathon - and that's ok! Stay in contact with your
+team on GitHub or Discord - we strongly encourage you to keep working 
+on your project, so your hard work doesn't go to waste.
+
+No code project is ever truly "finished", and we hope that you'll 
+stick around - whether this is maintaining and improving your new 
+contribution, or finding others ways you can contribute the broader 
+MDAnalysis ecosystem. We're always looking for more help!
 
 
 ## What should I work on?
@@ -39,6 +122,11 @@ problems of interest to the wider MDAnalysis community.
 If you are working on your code where you use MDAnalysis and you want
 to discuss it or need some help or ideas: then bring it and chat with
 some of the core developers or other users. 
+
+Raise an issue on the [UGM Issue Tracker][issue-tracker]; include 
+`[project]` at the start of the issue title, and share a link to the
+issue on the [#hackathon][hackathon-channel] discord channel to direct
+discussion there.
 
 ### Contribute to MDAnalysis!
 
@@ -79,3 +167,7 @@ professional renderings of MD trajectories. Under the hood, *Molecular
 Nodes* uses MDAnalysis for trajectory I/O. 
 
 For more details, go to the [blender](./blender) directory.
+
+[discord]: https://discord.com/invite/sAKgZZnPv4
+[hackathon-channel]: https://discord.com/channels/807348386012987462/1152628719354118205
+[issue-tracker]: https://github.com/MDAnalysis/UGM2023/issues

--- a/hackathon/README.md
+++ b/hackathon/README.md
@@ -116,7 +116,7 @@ on your project.
 
 No code project is ever truly "finished", and we hope that you'll 
 stick around - whether this is maintaining and improving your new 
-contribution, or finding others ways you can contribute the broader 
+contribution, or finding other ways to contribute the broader 
 MDAnalysis ecosystem. We're always looking for more help!
 
 

--- a/hackathon/README.md
+++ b/hackathon/README.md
@@ -20,7 +20,6 @@ the hackathon, during and after.
   Madrid Room. 
   
   Address: R. Soeiro Pereira Gomes 2, 1600-198 Lisbon, PT
-* **Contact**: @fiona-naughton (Fiona Naughton)
   
 ## Schedule 
 
@@ -29,9 +28,20 @@ the hackathon, during and after.
 | 9:30 - 10:00  | Registration                     |             |
 | 10:00 - 10:30 | Introduction and team gathering  | Madrid room |
 | 10:30 - 12:00 | Hackathon                        | Madrid room |
-| 12:00 - 13:00 | Lunch                            |             |
+| 12:00 - 13:00 | *Lunch*\*                        |             |
 | 13:00 - 14:30 | Hackathon                        | Madrid room |
 | 14:30 - 15:00 | Wrap-up and [showcase](#showcase)| Madrid room |
+
+\* **Lunch is not provided** as part of the hackathon; attendees must 
+make their own arrangements. There are a number of nearby resturants 
+to choose from. You are welcome to leave for (and return from) lunch 
+at any time; the listed hours are to indicate what times members 
+of the MDAnalysis team will be on hand to help you with any 
+questions. 
+
+Coffee and tea *will* be provided. 
+
+
 
 ## How do I participate?
 ### Before the hackathon

--- a/hackathon/README.md
+++ b/hackathon/README.md
@@ -112,7 +112,7 @@ an elevator pitch summary for your work ready!
 It's very possible that you won't "finish" a project within the 
 timelimit of the hackathon - and that's ok! Stay in contact with your
 team on GitHub or Discord - we strongly encourage you to keep working 
-on your project, so your hard work doesn't go to waste.
+on your project.
 
 No code project is ever truly "finished", and we hope that you'll 
 stick around - whether this is maintaining and improving your new 


### PR DESCRIPTION
Including 
 - adding an intro/showcase to the schedule and fixed starting time
 - general advice/instructions for the hackathon (from Oliver's comment in #11 and parts of the draft letter-to-hackathon attendees) 
 - link to discord #17 